### PR TITLE
jasmine: Don't call System.exit to report exit status.

### DIFF
--- a/bin/jasmine.in
+++ b/bin/jasmine.in
@@ -46,4 +46,4 @@ try {
     // Don't complain if config file absent from default location
 }
 
-System.exit(Command.run(_jasmine, ARGV, defaultConfig, 10));
+Command.run(_jasmine, ARGV, defaultConfig, 10);


### PR DESCRIPTION
Some test runners (eg, run-js-tests in gnome-shell) need to
embed the jasmine wrapper script and call it through
gjs_context_eval. Calling System.exit will prematurely
terminate those runners. This prevents things like
garbage collection or coverage statistics write-outs
from occurring.

A not-so-well publicised detail of JS_EvaluateScript is that
"return code" parameter is set to the value of the very
last expression statement in the script [1]. In this case,
that is the code of Command.run, which is passed to
System.exit. As such, we can rely on that behaviour
to set the exit code and test runners will do the right thing
and abort.

As for the normal GJS console - it won't abort straight away,
but it will return this value.

[1] https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/JSAPI_reference/JS::Evaluate
