### PR TITLE
Fix ByteArray warning on spidermonkey 60

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -6,6 +6,7 @@ const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Mainloop = imports.mainloop;
 const System = imports.system;
+const ByteArray = imports.byteArray;
 
 const Options = jasmineImporter.options;
 const Timer = jasmineImporter.timer;
@@ -34,7 +35,7 @@ function loadConfig(configFilePath) {
 
     try {
         let [, contents] = configFile.load_contents(null);
-        config = JSON.parse(contents);
+        config = JSON.parse(ByteArray.toString(contents));
     } catch (e) {
         throw new Error('Configuration not read from ' + configFile.get_path());
     }

--- a/src/command.js
+++ b/src/command.js
@@ -6,7 +6,6 @@ const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 const Mainloop = imports.mainloop;
 const System = imports.system;
-const ByteArray = imports.byteArray;
 
 const Options = jasmineImporter.options;
 const Timer = jasmineImporter.timer;
@@ -35,7 +34,10 @@ function loadConfig(configFilePath) {
 
     try {
         let [, contents] = configFile.load_contents(null);
-        config = JSON.parse(ByteArray.toString(contents));
+        if (contents instanceof Uint8Array) {
+            contents = imports.byteArray.toString(contents)
+        }
+        config = JSON.parse(contents);
     } catch (e) {
         throw new Error('Configuration not read from ' + configFile.get_path());
     }


### PR DESCRIPTION
With spidermonkey 60, a warning is shown when loading the JSON config file. This warning is silenced by using an explicit ByteArray.toString call.
See
https://www.reddit.com/r/gnome/comments/a39xfg/psa_gjs_and_bytearrays/