### PR TITLE
Launch a separate subprocess to run tests

### DIFF
--- a/bin/jasmine-runner.in
+++ b/bin/jasmine-runner.in
@@ -1,0 +1,42 @@
+#!/usr/bin/env gjs
+
+/* global jasmineImporter */
+
+const GLib = imports.gi.GLib;
+
+// Create a separate GJS importer object for Jasmine modules, so that Jasmine's
+// modules are not exposed to test code (e.g. client code might have its own
+// Utils module.)
+// This means that all imports within Jasmine must use jasmineImporter rather
+// than imports. That includes imports of Jasmine modules in the tests. It would
+// be better to test a separate copy of Jasmine code, but importing most modules
+// registers a GType, and we cannot register two GTypes with the same name in
+// the same process.
+
+if (GLib.getenv('JASMINE_UNINSTALLED')) {
+    // Trick to use the uninstalled copy of Jasmine when running "make check".
+    let srcdir = GLib.getenv('SRCDIR');
+    window.jasmineImporter = imports['.'];
+    jasmineImporter.searchPath = [
+        GLib.build_filenamev([srcdir, 'src']),
+        GLib.build_filenamev([srcdir, 'lib']),
+    ];
+} else {
+    let oldSearchPath = imports.searchPath.slice();  // make a copy
+    imports.searchPath.unshift('@datadir@');
+    window.jasmineImporter = imports['jasmine-gjs'];
+    imports.searchPath = oldSearchPath;
+}
+
+const Command = jasmineImporter.command;
+const Timer = jasmineImporter.timer;
+const JasmineBoot = jasmineImporter.jasmineBoot;
+
+Timer.installAPI(window);
+
+// Do not conflict with global "jasmine" object
+let _jasmine = new JasmineBoot.Jasmine();
+_jasmine.installAPI(window);
+
+// Don't put any code after this; the return value is used as the exit code.
+Command.run(_jasmine, ARGV, 10);

--- a/bin/jasmine.in
+++ b/bin/jasmine.in
@@ -1,47 +1,43 @@
 #!/usr/bin/env gjs
 
-/* global jasmineImporter */
-
+const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
+const System = imports.system;
 
-// Create a separate GJS importer object for Jasmine modules, so that Jasmine's
-// modules are not exposed to test code (e.g. client code might have its own
-// Utils module.)
-// This means that all imports within Jasmine must use jasmineImporter rather
-// than imports. That includes imports of Jasmine modules in the tests. It would
-// be better to test a separate copy of Jasmine code, but importing most modules
-// registers a GType, and we cannot register two GTypes with the same name in
-// the same process.
-
+let runner_path = '@pkglibexecdir@/jasmine-runner';
 if (GLib.getenv('JASMINE_UNINSTALLED')) {
     // Trick to use the uninstalled copy of Jasmine when running "make check".
     let srcdir = GLib.getenv('SRCDIR');
-    window.jasmineImporter = imports['.'];
-    jasmineImporter.searchPath = [
-        GLib.build_filenamev([srcdir, 'src']),
-        GLib.build_filenamev([srcdir, 'lib']),
-    ];
+    imports.searchPath.unshift(GLib.build_filenamev([srcdir, 'src']));
+    const builddir = GLib.getenv('BUILDDIR');
+    runner_path = GLib.build_filenamev([builddir, 'jasmine-runner']);
 } else {
-    let oldSearchPath = imports.searchPath.slice();  // make a copy
-    imports.searchPath.unshift('@datadir@');
-    window.jasmineImporter = imports['jasmine-gjs'];
-    imports.searchPath = oldSearchPath;
+    imports.searchPath.unshift('@datadir@/jasmine-gjs');
 }
 
-const Command = jasmineImporter.command;
-const Config = jasmineImporter.config;
-const Options = jasmineImporter.options;
+const Config = imports.config;
+const Options = imports.options;
 
-const Timer = jasmineImporter.timer;
-Timer.installAPI(window);
+let [files, options] = Options.parseOptions(ARGV);
 
-// Do not conflict with global "jasmine" object
-const JasmineBoot = jasmineImporter.jasmineBoot;
-let _jasmine = new JasmineBoot.Jasmine();
-_jasmine.installAPI(window);
+if (options.version) {
+    print('Jasmine @PACKAGE_VERSION@');
+    System.exit(0);
+}
 
-let [, options] = Options.parseOptions(ARGV);
 let config = Config.loadConfig(options);
 
+// Launch Jasmine in a subprocess so we can control the environment
+let launcher = new Gio.SubprocessLauncher();
+Config.prepareLauncher(launcher, config);
+let args = Config.configToArgs(config, files, options);
+args.unshift(runner_path);  // argv[0]
+let process = launcher.spawnv(args);
+process.wait(null);
+
 // Don't put any code after this; the return value is used as the exit code.
-Command.run(_jasmine, ARGV, config, 10);
+(function () {
+    if (process.get_if_exited())
+        return process.get_exit_status();
+    return 1;
+})();

--- a/meson.build
+++ b/meson.build
@@ -8,12 +8,21 @@ else
     gjs = find_program('gjs', 'gjs-console')
 endif
 
-# Executable
+pkglibexecdir = join_paths(get_option('libexecdir'), meson.project_name())
+
+# Executables
 
 config = configuration_data()
 config.set('datadir', join_paths(get_option('prefix'), get_option('datadir')))
+config.set('pkglibexecdir', join_paths(get_option('prefix'), pkglibexecdir))
+config.set('PACKAGE_VERSION', meson.project_version())
+
 jasmine = configure_file(configuration: config, input: 'bin/jasmine.in',
     output: 'jasmine', install: true, install_dir: 'bin')
+
+jasmine_runner = configure_file(configuration: config,
+    input: 'bin/jasmine-runner.in', output: 'jasmine-runner', install: true,
+    install_dir: pkglibexecdir)
 
 # Source code and Jasmine library
 
@@ -58,6 +67,7 @@ tests = [
 ]
 test_env = environment()
 test_env.set('SRCDIR', meson.current_source_dir())
+test_env.set('BUILDDIR', meson.current_build_dir())
 test_env.set('JASMINE_UNINSTALLED', 'yes')
 foreach t : tests
     test_file = files('test/@0@.js'.format(t))

--- a/src/config.js
+++ b/src/config.js
@@ -1,5 +1,4 @@
-/* global jasmineImporter */
-/* exported configToArgs, loadConfig */
+/* exported configToArgs, loadConfig, prepareLauncher */
 
 const Format = imports.format;
 const Gio = imports.gi.Gio;
@@ -7,14 +6,20 @@ const GLib = imports.gi.GLib;
 
 String.prototype.format = Format.format;
 
-const Utils = jasmineImporter.utils;
-
 function _makePathsAbsolute(configFile, paths) {
     return paths.map((path) => {
         if (GLib.path_is_absolute(path))
             return path;
         return configFile.get_parent().resolve_relative_path(path).get_path();
     });
+}
+
+// Make it legal to specify "some_option": "single_value" in the config file as
+// well as "some_option": ["multiple", "values"]
+function ensureArray(option) {
+    if (!(option instanceof Array))
+        return [option];
+    return option;
 }
 
 function loadConfig(options, defaultFile='jasmine.json') {
@@ -38,10 +43,10 @@ function loadConfig(options, defaultFile='jasmine.json') {
 
     if (config.include_paths)
         config.include_paths = _makePathsAbsolute(configFile,
-            Utils.ensureArray(config.include_paths));
+            ensureArray(config.include_paths));
     if (config.spec_files)
         config.spec_files = _makePathsAbsolute(configFile,
-            Utils.ensureArray(config.spec_files));
+            ensureArray(config.spec_files));
 
     const RECOGNIZED_KEYS = [
         'environment',
@@ -59,23 +64,59 @@ function loadConfig(options, defaultFile='jasmine.json') {
     return config;
 }
 
-function configToArgs(config, shouldAddSpecFiles=false) {
+function optionsToArgs(options) {
+    let args = [options.color? '--color' : '--no-color'];
+    if (options.verbose)
+        args.push('--verbose');
+    if (options.tap)
+        args.push('--tap');
+    if (options.junit) {
+        args.push('--junit');
+        args.push(options.junit);
+    }
+    if (options.exclude) {
+        ensureArray(options.exclude).forEach(exclude => {
+            args.push('--exclude');
+            args.push(exclude);
+        });
+    }
+    return args;
+}
+
+function configToArgs(config, specFiles=[], options={}) {
     let retval = [];
     if (config.include_paths) {
-        Utils.ensureArray(config.include_paths).forEach((path) => {
+        ensureArray(config.include_paths).forEach((path) => {
             retval.push('-I');
             retval.push(path);
         });
     }
     if (config.exclude) {
-        Utils.ensureArray(config.exclude).forEach((exclude) => {
+        ensureArray(config.exclude).forEach((exclude) => {
             retval.push('--exclude');
             retval.push(exclude);
         });
     }
+
+    // Command-line options should always override config file options
     if (config.options)
-        retval = retval.concat(Utils.ensureArray(config.options));
-    if (shouldAddSpecFiles && config.spec_files)
-        retval = retval.concat(Utils.ensureArray(config.spec_files));
+        retval = retval.concat(ensureArray(config.options));
+    retval = retval.concat(optionsToArgs(options), specFiles);
+    // Specific tests given on the command line should always override the
+    // default tests in the config file
+    if (specFiles.length === 0 && config.spec_files)
+        retval = retval.concat(ensureArray(config.spec_files));
+
     return retval;
+}
+
+function prepareLauncher(launcher, config) {
+    if (config.environment) {
+        Object.keys(config.environment).forEach(key => {
+            if (config.environment[key] === null)
+                launcher.unsetenv(key);
+            else
+                launcher.setenv(key, config.environment[key], true);
+        });
+    }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,12 +1,4 @@
-/* exported ensureArray, indent */
-
-// Make it legal to specify "some_option": "single_value" in the config file as
-// well as "some_option": ["multiple", "values"]
-function ensureArray(option) {
-    if (!(option instanceof Array))
-        return [option];
-    return option;
-}
+/* exported indent */
 
 function indent(str, spaces) {
     return str.split('\n').map((line) => {

--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -4,11 +4,22 @@ const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
 
 const Config = jasmineImporter.config;
+const Options = jasmineImporter.options;
 
 // This is in case we are running the tests from a build tree that is different
 // from the source tree, for example during 'make distcheck'.
 let envSrcdir = GLib.getenv('SRCDIR');
 const SRCDIR = envSrcdir? envSrcdir + '/' : '';
+
+describe('Ensure array', function () {
+    it('does not change an array', function () {
+        expect(Config.ensureArray(['a', 'b'])).toEqual(['a', 'b']);
+    });
+
+    it('puts a single value into an array', function () {
+        expect(Config.ensureArray('a')).toEqual(['a']);
+    });
+});
 
 describe('Loading configuration', function () {
     beforeEach(function () {
@@ -67,6 +78,15 @@ describe('Loading configuration', function () {
 });
 
 describe('Configuration options to arguments', function () {
+    it('lets command line arguments override config options', function () {
+        // COMPAT: spread operator in function args requires mozjs 27. This should read:
+        // let args = Config.configToArgs({ options: '--color' },
+        //   ...Options.parseOptions(['--no-color']));
+        let args = Config.configToArgs.apply(null, [{ options: '--color' },
+            ...Options.parseOptions(['--no-color'])]);
+        expect(args.indexOf('--no-color')).toBeGreaterThan(args.indexOf('--color'));
+    });
+
     it('adds one search path', function () {
         let args = Config.configToArgs({ include_paths: '/a' });
         expect(args.join(' ')).toMatch('-I /a');
@@ -78,6 +98,12 @@ describe('Configuration options to arguments', function () {
         expect(args.join(' ')).toMatch('-I /b');
     });
 
+    it('adds search paths in the right order', function () {
+        let args = Config.configToArgs({ include_paths: ['/a', '/b'] });
+        let argstring = args.join(' ');
+        expect(argstring.indexOf('-I /a')).toBeLessThan(argstring.indexOf('-I /b'));
+    });
+
     it('adds one exclusion path', function () {
         let args = Config.configToArgs({ exclude: 'a' });
         expect(args.join(' ')).toMatch('--exclude a');
@@ -87,6 +113,19 @@ describe('Configuration options to arguments', function () {
         let args = Config.configToArgs({ exclude: ['a', 'b'] });
         expect(args.join(' ')).toMatch('--exclude a');
         expect(args.join(' ')).toMatch('--exclude b');
+    });
+
+    it('adds exclusions from the command line', function () {
+        let args = Config.configToArgs.apply(null, [{},
+            ...Options.parseOptions(['--exclude', 'a.js'])]);
+        expect(args.join(' ')).toMatch('--exclude a.js');
+    });
+
+    it('combines exclusions from the command line and the config file', function () {
+        let args = Config.configToArgs.apply(null, [{ exclude: 'b.js' },
+            ...Options.parseOptions(['--exclude', 'a.js'])]);
+        expect(args.join(' ')).toMatch('--exclude a.js');
+        expect(args.join(' ')).toMatch('--exclude b.js');
     });
 
     it('adds one extra option', function () {
@@ -101,19 +140,74 @@ describe('Configuration options to arguments', function () {
     });
 
     it('adds one spec file', function () {
-        let args = Config.configToArgs({ spec_files: 'a' }, true);
+        let args = Config.configToArgs({ spec_files: 'a' });
         expect(args).toContain('a');
     });
 
     it('adds more than one spec file', function () {
-        let args = Config.configToArgs({ spec_files: ['a', 'b'] }, true);
+        let args = Config.configToArgs({ spec_files: ['a', 'b'] });
         expect(args).toContain('a');
         expect(args).toContain('b');
     });
 
-    it('does not add spec files unless requested', function () {
-        let args = Config.configToArgs({ spec_files: ['a', 'b'] });
+    it('does not add spec files from config if there were some on the command line', function () {
+        let args = Config.configToArgs({ spec_files: ['a', 'b'] }, ['c']);
         expect(args).not.toContain('a');
         expect(args).not.toContain('b');
+    });
+
+    it('passes the arguments on to the subprocess', function () {
+        let args = Config.configToArgs.apply(null, [{},
+            ...Options.parseOptions(['--color', 'spec.js'])]);
+        expect(args).toContain('--color', 'spec.js');
+    });
+
+    it('passes the config file on to the subprocess as arguments', function () {
+        let args = Config.configToArgs({
+            environment: {},
+            include_paths: ['/path1', '/path2'],
+            options: ['--color'],
+            exclude: ['nonspec*.js'],
+            spec_files: ['a.js', 'b.js'],
+        }, [], {});
+        expect(args.join(' ')).toMatch('-I /path1');
+        expect(args.join(' ')).toMatch('-I /path2');
+        expect(args.join(' ')).toMatch(/--exclude nonspec\*\.js/);
+        expect(args).toContain('--color', 'a.js', 'b.js');
+    });
+
+    it('does not pass the config file specs if specs were on the command line', function () {
+        let args = Config.configToArgs({
+            environment: {},
+            spec_files: ['spec2.js'],
+        }, ['spec1.js']);
+        expect(args).toContain('spec1.js');
+        expect(args).not.toContain('spec2.js');
+    });
+});
+
+describe('Manipulating the environment', function () {
+    let launcher;
+
+    beforeEach(function () {
+        launcher = jasmine.createSpyObj('launcher', ['setenv', 'unsetenv']);
+    });
+
+    it('sets environment variables in the launcher', function () {
+        Config.prepareLauncher(launcher, {
+            environment: {
+                'MY_VARIABLE': 'my_value',
+            },
+        });
+        expect(launcher.setenv).toHaveBeenCalledWith('MY_VARIABLE', 'my_value', true);
+    });
+
+    it('unsets environment variables with null values', function () {
+        Config.prepareLauncher(launcher, {
+            environment: {
+                'MY_VARIABLE': null,
+            },
+        });
+        expect(launcher.unsetenv).toHaveBeenCalledWith('MY_VARIABLE');
     });
 });

--- a/test/utilsSpec.js
+++ b/test/utilsSpec.js
@@ -20,13 +20,3 @@ describe('Indent', function () {
         expect(Utils.indent('a\nb\nc', 0)).toEqual('a\nb\nc');
     });
 });
-
-describe('Ensure array', function () {
-    it('does not change an array', function () {
-        expect(Utils.ensureArray(['a', 'b'])).toEqual(['a', 'b']);
-    });
-
-    it('puts a single value into an array', function () {
-        expect(Utils.ensureArray('a')).toEqual(['a']);
-    });
-});


### PR DESCRIPTION
Since introducing the feature that makes it possible to use the config
file to control the environment in which the tests are run, it has been
necessary to run the actual tests in a subprocess. Previously, Jasmine
would run itself as the subprocess. This was not so great, for several
reasons:

- The config file was read in twice, and printed two messages to that
  effect.

- Jasmine would only run a subprocess if you did want to modify the
  environment, so in some situations your tests would be run in a sub-
  process and in some situations they wouldn't.

This commit changes things so that the tests are always run in a
subprocess. The "jasmine" script is a launcher that reads the config file
and launches the subprocess, which is a "jasmine-runner" script in the
package's libexec directory.

All the config-file parsing code now belongs to the launcher. The runner
does not know about the config file; it is purely configured by the
arguments the launcher passes on its command line. The options.js module
is the only code loaded by both the launcher and the runner, because they
both need to parse command line options.

In addition, the config.js module now doesn't import any other modules.
The code has been made more testable in this and a few other ways.