### PR TITLE
Fix include paths being passed to subprocess

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -83,12 +83,6 @@ function optionsToArgs(options) {
 
 function configToArgs(config, specFiles = [], options = {}) {
     let retval = [];
-    if (config.include_paths) {
-        ensureArray(config.include_paths).forEach(path => {
-            retval.push('-I');
-            retval.push(path);
-        });
-    }
     if (config.exclude) {
         ensureArray(config.exclude).forEach(exclude => {
             retval.push('--exclude');
@@ -120,6 +114,13 @@ function prepareLauncher(config, options = {}) {
             else
                 launcher.setenv(key, config.environment[key], true);
         });
+    }
+    if (config.include_paths) {
+        const existingPaths = launcher.getenv('GJS_PATH');
+        const paths = ensureArray(config.include_paths).slice();
+        if (existingPaths)
+            paths.unshift(existingPaths);
+        launcher.setenv('GJS_PATH', paths.join(':'), /* overwrite = */ true);
     }
     return launcher;
 }

--- a/src/options.js
+++ b/src/options.js
@@ -73,14 +73,18 @@ function parseOptions(argv) {
 
     let argvElement;
     while ((argvElement = argv.shift())) {
-        if (!argvElement.startsWith('--')) {
+        if (!argvElement.startsWith('-')) {
             files.push(argvElement);
             continue;
         }
 
+        if (!argvElement.startsWith('--')) {
+            printerr(`warning: Unknown argument "${argvElement}"`);
+            continue;
+        }
         const argName = argvElement.slice(2);
         if (!(argName in ARGS)) {
-            printerr(`warning: Unknown argument "${argName}"`);
+            printerr(`warning: Unknown argument "${argvElement}"`);
             continue;
         }
 

--- a/test/fixtures/include.json
+++ b/test/fixtures/include.json
@@ -1,0 +1,4 @@
+{
+    "include_paths": "include",
+    "spec_files": "someSpec.js"
+}

--- a/test/fixtures/include/module.js
+++ b/test/fixtures/include/module.js
@@ -1,0 +1,5 @@
+/* exported importedFunction */
+
+function importedFunction() {
+    return true;
+}

--- a/test/fixtures/include/spec.js
+++ b/test/fixtures/include/spec.js
@@ -1,0 +1,5 @@
+describe('A spec that should not be loaded', function () {
+    it('is not loaded', function () {
+        fail('Spec was loaded when it should not be');
+    });
+});

--- a/test/jasmineBootSpec.js
+++ b/test/jasmineBootSpec.js
@@ -115,6 +115,8 @@ describe('Jasmine boot', function () {
         expect(testJasmine.specFiles).toEqual([]);
         testJasmine.addSpecFiles([`${SRCDIR}test/fixtures`]);
         expect(testJasmine.specFiles).toMatchAllFiles([
+            `${SRCDIR}test/fixtures/include/module.js`,
+            `${SRCDIR}test/fixtures/include/spec.js`,
             `${SRCDIR}test/fixtures/otherSpec.js`,
             `${SRCDIR}test/fixtures/path1/test.js`,
             `${SRCDIR}test/fixtures/path2/test.js`,
@@ -139,6 +141,8 @@ describe('Jasmine boot', function () {
         testJasmine.exclusions = ['otherSpec.js', 'syntaxErrorSpec.js'];
         testJasmine.addSpecFiles([`${SRCDIR}test/fixtures`]);
         expect(testJasmine.specFiles).toMatchAllFiles([
+            `${SRCDIR}test/fixtures/include/module.js`,
+            `${SRCDIR}test/fixtures/include/spec.js`,
             `${SRCDIR}test/fixtures/someSpec.js`,
             `${SRCDIR}test/fixtures/path1/test.js`,
             `${SRCDIR}test/fixtures/path2/test.js`,
@@ -149,6 +153,8 @@ describe('Jasmine boot', function () {
         testJasmine.exclusions = ['test/fixtures'];
         testJasmine.addSpecFiles([`${SRCDIR}test/fixtures`]);
         expect(testJasmine.specFiles).toMatchAllFiles([
+            `${SRCDIR}test/fixtures/include/module.js`,
+            `${SRCDIR}test/fixtures/include/spec.js`,
             `${SRCDIR}test/fixtures/path1/test.js`,
             `${SRCDIR}test/fixtures/path2/test.js`,
         ]);

--- a/test/optionsSpec.js
+++ b/test/optionsSpec.js
@@ -41,4 +41,9 @@ describe('Argument parser', function () {
         Options.parseOptions(args);
         expect(args.length).toBe(3);
     });
+
+    it('does not treat a short option as a file', function () {
+        const [files] = Options.parseOptions(['-c', 'file.js']);
+        expect(files).toEqual(['file.js']);
+    });
 });


### PR DESCRIPTION
Previously include paths in the config file were treated as spec paths.

Closes: #37