### PR TITLE
Print test plan first

### DIFF
--- a/jasmine-gjs.spec
+++ b/jasmine-gjs.spec
@@ -46,7 +46,7 @@ be displayed in your terminal.
 
 
 %changelog
-* Mon Aug 26 2020 Andy Holmes <andrew.g.r.holmes@gmail.com> - 2.3.4-1
+* Wed Aug 26 2020 Andy Holmes <andrew.g.r.holmes@gmail.com> - 2.3.4-1
 - Update to version 2.3.4.
 * Mon Aug 24 2020 Philip Chimento <philip.chimento@gmail.com> - 2.3.0-1
 - Update to version 2.3.0.

--- a/src/tapReporter.js
+++ b/src/tapReporter.js
@@ -9,20 +9,17 @@ const {GObject} = imports.gi;
 const {ConsoleReporter} = jasmineImporter.consoleReporter;
 
 var TapReporter = GObject.registerClass(class TapReporter extends ConsoleReporter {
+    jasmineStarted(info) {
+        super.jasmineStarted(info);
+        this._print(`1..${info.totalSpecsDefined}\n`);
+    }
+
     jasmineDone() {
         this._failedSuites.forEach(failure => {
             failure.failedExpectations.forEach(result => {
                 this._print(`not ok - An error was thrown in an afterAll(): ${result.message}\n`);
             });
         });
-
-        // Output the test plan
-        // TODO: This should be output at the start of the run, using
-        // info.totalSpecsDefined, in order to account for specs that are
-        // skipped. Unfortunately that number doesn't include specs disabled
-        // due to other specs being focused.
-        this._print(`1..${this._specCount}\n`);
-
         super.jasmineDone();
     }
 


### PR DESCRIPTION
Due to a limitation in older Jasmine, the TAP reporter had to output the test plan at the end of the tests, which is allowed but not preferred according to the TAP protocol. This limitation was fixed, so we can now output the test plan first.