### PR TITLE
Remove construct-only flag from property that is set after construct

### DIFF
--- a/src/consoleReporter.js
+++ b/src/consoleReporter.js
@@ -28,7 +28,7 @@ var ConsoleReporter = GObject.registerClass({
         'jasmine-core-path': GObject.ParamSpec.string('jasmine-core-path',
             'Jasmine core path',
             'Path to Jasmine core module for stack trace purposes',
-            GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+            GObject.ParamFlags.READWRITE,
             '/nowhere'),
     },
 


### PR DESCRIPTION
GJS 1.68 fixes a bug where setting a construct-only GObject property would
be ignored. Now that it prints a warning, it's clear that this property
wasn't being treated as construct-only; remove the flag.