### PR TITLE
build: Allow using as meson subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,8 @@ jasmine_runner = configure_file(configuration: config,
     input: 'bin/jasmine-runner.in', output: 'jasmine-runner', install: true,
     install_dir: pkglibexecdir)
 
+meson.override_find_program('jasmine', jasmine)
+
 # Source code and Jasmine library
 
 install_data(


### PR DESCRIPTION
Mark the `jasmine` target as a possible provider of a `find_program('jasmine')` dependency. This allows
projects to pull in jasmine-gjs as wrap/subproject.