### PR TITLE
Make use as subproject easier

### DIFF
--- a/bin/jasmine-runner.in
+++ b/bin/jasmine-runner.in
@@ -4,6 +4,9 @@
 
 import GLib from 'gi://GLib';
 
+const pkgdatadir = GLib.getenv('TEST_PKGDATADIR') ?? '@pkgdatadir@';
+const jasmineMod = GLib.getenv('TEST_JASMINE_MOD') ?? '@jasmine_mod@';
+
 // Create a separate GJS importer object for Jasmine modules, so that Jasmine's
 // modules are not exposed to test code (e.g. client code might have its own
 // Utils module.)
@@ -13,22 +16,12 @@ import GLib from 'gi://GLib';
 // registers a GType, and we cannot register two GTypes with the same name in
 // the same process.
 
-let base;
-if (GLib.getenv('JASMINE_UNINSTALLED')) {
-    // Trick to use the uninstalled copy of Jasmine when running "make check".
-    const srcdir = GLib.getenv('SRCDIR');
-    globalThis.jasmineImporter = imports['.'];
-    jasmineImporter.searchPath = [
-        GLib.build_filenamev([srcdir, 'lib']),
-    ];
-    base = `file://${GLib.build_filenamev([srcdir, 'src'])}`;
-} else {
-    const oldSearchPath = imports.searchPath.slice();  // make a copy
-    imports.searchPath.unshift(GLib.path_get_dirname('@pkgdatadir@'));
-    globalThis.jasmineImporter = imports['@jasmine_mod@'];
-    imports.searchPath = oldSearchPath;
-    base = 'file://@pkgdatadir@';
-}
+const oldSearchPath = imports.searchPath.slice();  // make a copy
+imports.searchPath.unshift(GLib.path_get_dirname(pkgdatadir));
+globalThis.jasmineImporter = imports[jasmineMod];
+imports.searchPath = oldSearchPath;
+
+const base = `file://${pkgdatadir}`;
 
 const Command = await import(`${base}/command.js`);
 const JasmineBoot = await import(`${base}/jasmineBoot.js`);

--- a/bin/jasmine-runner.in
+++ b/bin/jasmine-runner.in
@@ -24,10 +24,10 @@ if (GLib.getenv('JASMINE_UNINSTALLED')) {
     base = `file://${GLib.build_filenamev([srcdir, 'src'])}`;
 } else {
     const oldSearchPath = imports.searchPath.slice();  // make a copy
-    imports.searchPath.unshift('@datadir@');
-    globalThis.jasmineImporter = imports['jasmine-gjs'];
+    imports.searchPath.unshift(GLib.path_get_dirname('@pkgdatadir@'));
+    globalThis.jasmineImporter = imports['@jasmine_mod@'];
     imports.searchPath = oldSearchPath;
-    base = 'file://@datadir@/jasmine-gjs';
+    base = 'file://@pkgdatadir@';
 }
 
 const Command = await import(`${base}/command.js`);

--- a/bin/jasmine.in
+++ b/bin/jasmine.in
@@ -3,17 +3,11 @@
 import GLib from 'gi://GLib';
 import * as System from 'system';
 
-let runnerPath = '@pkglibexecdir@/jasmine-runner';
-let base;
-if (GLib.getenv('JASMINE_UNINSTALLED')) {
-    // Trick to use the uninstalled copy of Jasmine when running "make check".
-    const srcdir = GLib.getenv('SRCDIR');
-    base = `file://${GLib.build_filenamev([srcdir, 'src'])}`;
-    const builddir = GLib.getenv('BUILDDIR');
-    runnerPath = GLib.build_filenamev([builddir, 'jasmine-runner']);
-} else {
-    base = 'file://@pkgdatadir@';
-}
+const pkglibexecdir = GLib.getenv('TEST_PKGLIBEXECDIR') ?? '@pkglibexecdir@';
+const pkgdatadir = GLib.getenv('TEST_PKGDATADIR') ?? '@pkgdatadir@';
+
+const runnerPath = `${pkglibexecdir}/jasmine-runner`;
+const base = `file://${pkgdatadir}`;
 
 const Config = await import(`${base}/config.js`);
 const Options = await import(`${base}/options.js`);

--- a/bin/jasmine.in
+++ b/bin/jasmine.in
@@ -12,7 +12,7 @@ if (GLib.getenv('JASMINE_UNINSTALLED')) {
     const builddir = GLib.getenv('BUILDDIR');
     runnerPath = GLib.build_filenamev([builddir, 'jasmine-runner']);
 } else {
-    base = 'file://@datadir@/jasmine-gjs';
+    base = 'file://@pkgdatadir@';
 }
 
 const Config = await import(`${base}/config.js`);

--- a/meson.build
+++ b/meson.build
@@ -19,9 +19,15 @@ uninstalled_jasmine_mod = 'lib'
 # Executables
 
 config = configuration_data()
-config.set('pkgdatadir', join_paths(get_option('prefix'), pkgdatadir))
-config.set('pkglibexecdir', join_paths(get_option('prefix'), pkglibexecdir))
-config.set('jasmine_mod', jasmine_mod)
+if meson.is_subproject()
+    config.set('pkgdatadir', uninstalled_pkgdatadir)
+    config.set('pkglibexecdir', uninstalled_pkglibexecdir)
+    config.set('jasmine_mod', uninstalled_jasmine_mod)
+else
+    config.set('pkgdatadir', join_paths(get_option('prefix'), pkgdatadir))
+    config.set('pkglibexecdir', join_paths(get_option('prefix'), pkglibexecdir))
+    config.set('jasmine_mod', jasmine_mod)
+endif
 config.set('PACKAGE_VERSION', meson.project_version())
 
 jasmine = configure_file(configuration: config, input: 'bin/jasmine.in',

--- a/meson.build
+++ b/meson.build
@@ -25,36 +25,41 @@ config.set('jasmine_mod', jasmine_mod)
 config.set('PACKAGE_VERSION', meson.project_version())
 
 jasmine = configure_file(configuration: config, input: 'bin/jasmine.in',
-    output: 'jasmine', install: true, install_dir: 'bin')
+    output: 'jasmine', install: not meson.is_subproject(), install_dir: 'bin')
 
 jasmine_runner = configure_file(configuration: config,
-    input: 'bin/jasmine-runner.in', output: 'jasmine-runner', install: true,
+    input: 'bin/jasmine-runner.in', output: 'jasmine-runner',
+    install: not meson.is_subproject(),
     install_dir: pkglibexecdir)
 
 meson.override_find_program('jasmine', jasmine)
 
 # Source code and Jasmine library
 
-install_data(
-    'lib/jasmine.js',
-    'src/command.js',
-    'src/config.js',
-    'src/consoleReporter.js',
-    'src/jasmineBoot.js',
-    'src/junitReporter.js',
-    'src/options.js',
-    'src/tapReporter.js',
-    'src/timer.js',
-    'src/utils.js',
-    'src/verboseReporter.js',
-    'src/xmlWriter.js',
-    install_dir: pkgdatadir,
-)
+if not meson.is_subproject()
+    install_data(
+        'lib/jasmine.js',
+        'src/command.js',
+        'src/config.js',
+        'src/consoleReporter.js',
+        'src/jasmineBoot.js',
+        'src/junitReporter.js',
+        'src/options.js',
+        'src/tapReporter.js',
+        'src/timer.js',
+        'src/utils.js',
+        'src/verboseReporter.js',
+        'src/xmlWriter.js',
+        install_dir: pkgdatadir,
+    )
+endif
 
 # Documentation
 
-install_data('jasmine.man', rename: 'jasmine.1',
-    install_dir: join_paths(get_option('datadir'), 'man', 'man1'))
+if not meson.is_subproject()
+    install_data('jasmine.man', rename: 'jasmine.1',
+        install_dir: join_paths(get_option('datadir'), 'man', 'man1'))
+endif
 
 # Tests
 

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,10 @@ pkglibexecdir = join_paths(get_option('libexecdir'), meson.project_name())
 pkgdatadir = join_paths(get_option('datadir'), meson.project_name())
 jasmine_mod = meson.project_name()
 
+uninstalled_pkglibexecdir = meson.current_build_dir()
+uninstalled_pkgdatadir = join_paths(meson.current_source_dir(), 'src')
+uninstalled_jasmine_mod = 'lib'
+
 # Executables
 
 config = configuration_data()
@@ -72,9 +76,9 @@ tests = [
     'xmlWriterSpec',
 ]
 test_env = environment()
-test_env.set('SRCDIR', meson.current_source_dir())
-test_env.set('BUILDDIR', meson.current_build_dir())
-test_env.set('JASMINE_UNINSTALLED', 'yes')
+test_env.set('TEST_PKGDATADIR', uninstalled_pkgdatadir)
+test_env.set('TEST_PKGLIBEXECDIR', uninstalled_pkglibexecdir)
+test_env.set('TEST_JASMINE_MOD', uninstalled_jasmine_mod)
 foreach t : tests
     test_file = files('test/@0@.js'.format(t))
     test(t, gjs, args: ['-m', jasmine, test_file, '--module', '--tap', '--no-config'],

--- a/meson.build
+++ b/meson.build
@@ -9,12 +9,15 @@ else
 endif
 
 pkglibexecdir = join_paths(get_option('libexecdir'), meson.project_name())
+pkgdatadir = join_paths(get_option('datadir'), meson.project_name())
+jasmine_mod = meson.project_name()
 
 # Executables
 
 config = configuration_data()
-config.set('datadir', join_paths(get_option('prefix'), get_option('datadir')))
+config.set('pkgdatadir', join_paths(get_option('prefix'), pkgdatadir))
 config.set('pkglibexecdir', join_paths(get_option('prefix'), pkglibexecdir))
+config.set('jasmine_mod', jasmine_mod)
 config.set('PACKAGE_VERSION', meson.project_version())
 
 jasmine = configure_file(configuration: config, input: 'bin/jasmine.in',
@@ -41,7 +44,7 @@ install_data(
     'src/utils.js',
     'src/verboseReporter.js',
     'src/xmlWriter.js',
-    install_dir: join_paths(get_option('datadir'), meson.project_name()),
+    install_dir: pkgdatadir,
 )
 
 # Documentation

--- a/meson.build
+++ b/meson.build
@@ -75,12 +75,14 @@ tests = [
     'verboseReporterSpec',
     'xmlWriterSpec',
 ]
-test_env = environment()
-test_env.set('TEST_PKGDATADIR', uninstalled_pkgdatadir)
-test_env.set('TEST_PKGLIBEXECDIR', uninstalled_pkglibexecdir)
-test_env.set('TEST_JASMINE_MOD', uninstalled_jasmine_mod)
-foreach t : tests
-    test_file = files('test/@0@.js'.format(t))
-    test(t, gjs, args: ['-m', jasmine, test_file, '--module', '--tap', '--no-config'],
-        env: test_env, protocol: 'tap')
-endforeach
+if not meson.is_subproject()
+    test_env = environment()
+    test_env.set('TEST_PKGDATADIR', uninstalled_pkgdatadir)
+    test_env.set('TEST_PKGLIBEXECDIR', uninstalled_pkglibexecdir)
+    test_env.set('TEST_JASMINE_MOD', uninstalled_jasmine_mod)
+    foreach t : tests
+        test_file = files('test/@0@.js'.format(t))
+        test(t, gjs, args: ['-m', jasmine, test_file, '--module', '--tap', '--no-config'],
+            env: test_env, protocol: 'tap')
+    endforeach
+endif

--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -4,10 +4,8 @@ import GLib from 'gi://GLib';
 import * as Config from '../src/config.js';
 import * as Options from '../src/options.js';
 
-// This is in case we are running the tests from a build tree that is different
-// from the source tree, for example during 'meson test'.
-const envSrcdir = GLib.getenv('SRCDIR');
-const SRCDIR = envSrcdir ? `${envSrcdir}/` : '';
+const [testFile] = GLib.filename_from_uri(import.meta.url);
+const testDir = GLib.path_get_dirname(testFile);
 
 describe('Ensure array', function () {
     it('does not change an array', function () {
@@ -27,7 +25,7 @@ describe('Loading configuration', function () {
     });
 
     it('loads from a file', function () {
-        const config = Config.loadConfig({config: `${SRCDIR}test/fixtures/jasmine.json`});
+        const config = Config.loadConfig({config: `${testDir}/fixtures/jasmine.json`});
         expect(config.a).toEqual('b');
         expect(config.c).toEqual('d');
     });
@@ -35,7 +33,7 @@ describe('Loading configuration', function () {
     it("doesn't load the file if no-config specified", function () {
         const config = Config.loadConfig({
             'no-config': true,
-            config: `${SRCDIR}test/fixtures/jasmine.json`,
+            config: `${testDir}/fixtures/jasmine.json`,
         });
         const keys = Object.keys(config);
         expect(keys).not.toContain('a');
@@ -43,7 +41,7 @@ describe('Loading configuration', function () {
     });
 
     it('loads the default file if none given', function () {
-        const config = Config.loadConfig({}, `${SRCDIR}test/fixtures/jasmine.json`);
+        const config = Config.loadConfig({}, `${testDir}/fixtures/jasmine.json`);
         expect(config.a).toEqual('b');
         expect(config.c).toEqual('d');
     });
@@ -58,20 +56,20 @@ describe('Loading configuration', function () {
 
     it('errors out if the file is invalid', function () {
         expect(() => Config.loadConfig({
-            config: `${SRCDIR}test/fixtures/invalid.json`,
+            config: `${testDir}/fixtures/invalid.json`,
         })).toThrow();
     });
 
     it("resolves paths relative to the config file's location", function () {
-        const config = Config.loadConfig({config: `${SRCDIR}test/fixtures/path.json`});
-        const location = Gio.File.new_for_path(`${SRCDIR}test/fixtures`);
+        const config = Config.loadConfig({config: `${testDir}/fixtures/path.json`});
+        const location = Gio.File.new_for_path(`${testDir}/fixtures`);
 
         expect(config.include_paths).toContain(location.get_path());
         expect(config.spec_files).toContain(location.get_child('someSpec.js').get_path());
     });
 
     it('warns about unrecognized config options', function () {
-        Config.loadConfig({config: `${SRCDIR}test/fixtures/jasmine.json`});
+        Config.loadConfig({config: `${testDir}/fixtures/jasmine.json`});
         expect(globalThis.printerr).toHaveBeenCalledWith(jasmine.stringMatching(/^warning: /));
     });
 });

--- a/test/jasmineBootSpec.js
+++ b/test/jasmineBootSpec.js
@@ -3,10 +3,8 @@ import GLib from 'gi://GLib';
 
 import * as JasmineBoot from '../src/jasmineBoot.js';
 
-// This is in case we are running the tests from a build tree that is different
-// from the source tree, for example during 'make distcheck'.
-const envSrcdir = GLib.getenv('SRCDIR');
-const SRCDIR = envSrcdir ? `${envSrcdir}/` : '';
+const [testFile] = GLib.filename_from_uri(import.meta.url);
+const testDir = GLib.path_get_dirname(testFile);
 
 const customMatchers = {
     toMatchAllFiles() {
@@ -85,84 +83,84 @@ describe('Jasmine boot', function () {
 
     it('adds a nonexistent spec file', function () {
         expect(testJasmine.specFiles).toEqual([]);
-        testJasmine.addSpecFiles([`${SRCDIR}non/existent/file.js`]);
+        testJasmine.addSpecFiles([`${testDir}/non/existent/file.js`]);
         expect(testJasmine.specFiles).toMatchAllFiles([
-            `${SRCDIR}non/existent/file.js`,
+            `${testDir}/non/existent/file.js`,
         ]);
     });
 
     it('adds a real spec file', function () {
         expect(testJasmine.specFiles).toEqual([]);
-        testJasmine.addSpecFiles([`${SRCDIR}test/fixtures/someSpec.js`]);
+        testJasmine.addSpecFiles([`${testDir}/fixtures/someSpec.js`]);
         expect(testJasmine.specFiles).toMatchAllFiles([
-            `${SRCDIR}test/fixtures/someSpec.js`,
+            `${testDir}/fixtures/someSpec.js`,
         ]);
     });
 
     it('adds more than one spec file', function () {
         expect(testJasmine.specFiles).toEqual([]);
         testJasmine.addSpecFiles([
-            `${SRCDIR}test/fixtures/someSpec.js`,
-            `${SRCDIR}test/fixtures/otherSpec.js`,
+            `${testDir}/fixtures/someSpec.js`,
+            `${testDir}/fixtures/otherSpec.js`,
         ]);
         expect(testJasmine.specFiles).toMatchAllFiles([
-            `${SRCDIR}test/fixtures/someSpec.js`,
-            `${SRCDIR}test/fixtures/otherSpec.js`,
+            `${testDir}/fixtures/someSpec.js`,
+            `${testDir}/fixtures/otherSpec.js`,
         ]);
     });
 
     it('adds a whole directory of spec files', function () {
         expect(testJasmine.specFiles).toEqual([]);
-        testJasmine.addSpecFiles([`${SRCDIR}test/fixtures`]);
+        testJasmine.addSpecFiles([`${testDir}/fixtures`]);
         expect(testJasmine.specFiles).toMatchAllFiles([
-            `${SRCDIR}test/fixtures/include/module.js`,
-            `${SRCDIR}test/fixtures/include/spec.js`,
-            `${SRCDIR}test/fixtures/otherSpec.js`,
-            `${SRCDIR}test/fixtures/path1/test.js`,
-            `${SRCDIR}test/fixtures/path2/test.js`,
-            `${SRCDIR}test/fixtures/someSpec.js`,
-            `${SRCDIR}test/fixtures/syntaxErrorSpec.js`,
+            `${testDir}/fixtures/include/module.js`,
+            `${testDir}/fixtures/include/spec.js`,
+            `${testDir}/fixtures/otherSpec.js`,
+            `${testDir}/fixtures/path1/test.js`,
+            `${testDir}/fixtures/path2/test.js`,
+            `${testDir}/fixtures/someSpec.js`,
+            `${testDir}/fixtures/syntaxErrorSpec.js`,
         ]);
         expect(testJasmine.specFiles.every(path => path.indexOf('notASpec.txt') === -1)).toBe(true);
     });
 
     it('adds spec files in different directories with the same name', function () {
         testJasmine.addSpecFiles([
-            `${SRCDIR}test/fixtures/path1`,
-            `${SRCDIR}test/fixtures/path2`,
+            `${testDir}/fixtures/path1`,
+            `${testDir}/fixtures/path2`,
         ]);
         expect(testJasmine.specFiles).toMatchAllFiles([
-            `${SRCDIR}test/fixtures/path1/test.js`,
-            `${SRCDIR}test/fixtures/path2/test.js`,
+            `${testDir}/fixtures/path1/test.js`,
+            `${testDir}/fixtures/path2/test.js`,
         ]);
     });
 
     it('respects excluded files', function () {
         testJasmine.exclusions = ['otherSpec.js', 'syntaxErrorSpec.js'];
-        testJasmine.addSpecFiles([`${SRCDIR}test/fixtures`]);
+        testJasmine.addSpecFiles([`${testDir}/fixtures`]);
         expect(testJasmine.specFiles).toMatchAllFiles([
-            `${SRCDIR}test/fixtures/include/module.js`,
-            `${SRCDIR}test/fixtures/include/spec.js`,
-            `${SRCDIR}test/fixtures/someSpec.js`,
-            `${SRCDIR}test/fixtures/path1/test.js`,
-            `${SRCDIR}test/fixtures/path2/test.js`,
+            `${testDir}/fixtures/include/module.js`,
+            `${testDir}/fixtures/include/spec.js`,
+            `${testDir}/fixtures/someSpec.js`,
+            `${testDir}/fixtures/path1/test.js`,
+            `${testDir}/fixtures/path2/test.js`,
         ]);
     });
 
     it('matches at the end of the containing path', function () {
         testJasmine.exclusions = ['test/fixtures'];
-        testJasmine.addSpecFiles([`${SRCDIR}test/fixtures`]);
+        testJasmine.addSpecFiles([`${testDir}/fixtures`]);
         expect(testJasmine.specFiles).toMatchAllFiles([
-            `${SRCDIR}test/fixtures/include/module.js`,
-            `${SRCDIR}test/fixtures/include/spec.js`,
-            `${SRCDIR}test/fixtures/path1/test.js`,
-            `${SRCDIR}test/fixtures/path2/test.js`,
+            `${testDir}/fixtures/include/module.js`,
+            `${testDir}/fixtures/include/spec.js`,
+            `${testDir}/fixtures/path1/test.js`,
+            `${testDir}/fixtures/path2/test.js`,
         ]);
     });
 
     it('can handle globs in excluded files', function () {
         testJasmine.exclusions = ['*.js'];
-        testJasmine.addSpecFiles([`${SRCDIR}test/fixtures`]);
+        testJasmine.addSpecFiles([`${testDir}/fixtures`]);
         expect(testJasmine.specFiles).toMatchAllFiles([]);
     });
 
@@ -174,15 +172,15 @@ describe('Jasmine boot', function () {
 
     it('imports spec files in different directories with the same name', function () {
         testJasmine.addSpecFiles([
-            `${SRCDIR}test/fixtures/path1`,
-            `${SRCDIR}test/fixtures/path2`,
+            `${testDir}/fixtures/path1`,
+            `${testDir}/fixtures/path2`,
         ]);
         expectAsync(testJasmine.loadSpecs()).toBeRejectedWithError(Error,
             'Catch this error to ensure this file is loaded');
     });
 
     it('does not bail out altogether if one of the specs has a syntax error', function () {
-        testJasmine.addSpecFiles([`${SRCDIR}test/fixtures/syntaxErrorSpec.js`]);
+        testJasmine.addSpecFiles([`${testDir}/fixtures/syntaxErrorSpec.js`]);
         expect(() => testJasmine.loadSpecs()).not.toThrow();
     });
 


### PR DESCRIPTION
While it is possible to use jasmine-gjs as meson subproject after
commit 6fbd6d8c9, there are a couple of issues with it:

 - the jasmine test suite is added to the project tests
 - jasmine is installed alongside the project
 - projects needs to set up an environment with
   `JASMINE_UNINSTALLED` and friends, but *only* when
   falling back to the subproject

Address those by special-casing the use in a subproject, and
 - skip tests
 - don't install anything
 - generate jasmine/runner to run installed without env vars

The first two seem pretty common for build dependencies (gi-docgen,
blueprint-compiler). Doing the same for a test dependency doesn't
seem too far fetched.
