### PR TITLE
bin: Fix exit code propagation

### DIFF
--- a/bin/jasmine-runner.in
+++ b/bin/jasmine-runner.in
@@ -3,6 +3,7 @@
 /* global jasmineImporter */
 
 import GLib from 'gi://GLib';
+import System from 'system';
 
 const pkgdatadir = GLib.getenv('TEST_PKGDATADIR') ?? '@pkgdatadir@';
 const jasmineMod = GLib.getenv('TEST_JASMINE_MOD') ?? '@jasmine_mod@';
@@ -30,5 +31,4 @@ const JasmineBoot = await import(`${base}/jasmineBoot.js`);
 const _jasmine = new JasmineBoot.Jasmine();
 _jasmine.installAPI(globalThis);
 
-// Don't put any code after this; the return value is used as the exit code.
-await Command.run(_jasmine, ARGV, 10);
+System.exit(await Command.run(_jasmine, ARGV, 10));

--- a/bin/jasmine.in
+++ b/bin/jasmine.in
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S gjs -m
 
 import GLib from 'gi://GLib';
-import * as System from 'system';
+import System from 'system';
 
 const pkglibexecdir = GLib.getenv('TEST_PKGLIBEXECDIR') ?? '@pkglibexecdir@';
 const pkgdatadir = GLib.getenv('TEST_PKGDATADIR') ?? '@pkgdatadir@';
@@ -29,9 +29,7 @@ args = Config.wrapArgs(args, config, options);
 const process = launcher.spawnv(args);
 process.wait(null);
 
-// Don't put any code after this; the return value is used as the exit code.
-(function () {
-    if (process.get_if_exited())
-        return process.get_exit_status();
-    return 1;
-})();
+if (process.get_if_exited())
+    System.exit(process.get_exit_status());
+
+System.exit(1);


### PR DESCRIPTION
Now that we're loading entrypoints as modules, exit codes no longer propagate  in the same way. Therefore, we  must do that explicitly through the system exit function.

Without this the exit code is always  ZERO and in practical terms all CI pipelines depending on this are always passing even when the tests are actually failing.

See 7825a0c.

To reproduce:

1. Build latest jasmine-gjs from master (c6aa28b).

2. Use the following sample test.

```javascript
describe('test', function() {

    it('fails', function() {
        expect('one').toEqual('two');
    });
});
```

3. Run it:

```sh
$ jasmine --no-config --verbose --no-color sample.js
$ echo $?
```

With out this PR the exit code is always ZERO.