### PR TITLE
consoleReporter: Fix warning with newer GIO versions

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Philip Chimento <philip.chimento@gmail.com>
 Build-Depends: debhelper-compat (= 12),
                gir1.2-glib-2.0,
-               gjs (>= 1.68.0),
+               gjs (>= 1.71.1),
                meson (>= 0.58.0)
 Standards-Version: 4.5.0
 Homepage: https://github.com/ptomato/jasmine-gjs
@@ -13,7 +13,7 @@ Package: jasmine-gjs
 Architecture: all
 Depends: ${misc:Depends},
          gir1.2-glib-2.0,
-         gjs (>= 1.68.0)
+         gjs (>= 1.71.1)
 Description: Behavior-driven development framework for GJS
  This module allows you to run Jasmine specs for your GJS code. The output will
  be displayed in your terminal.

--- a/jasmine-gjs.spec
+++ b/jasmine-gjs.spec
@@ -8,10 +8,10 @@ URL: https://github.com/ptomato/jasmine-gjs
 Source0: https://github.com/ptomato/jasmine-gjs/releases/download/3.10.1/jasmine-gjs-3.10.1.tar.xz
 
 BuildArch: noarch
-BuildRequires: gjs >= 1.68.0
+BuildRequires: gjs >= 1.71.1
 BuildRequires: gobject-introspection
 BuildRequires: meson >= 0.58.0
-Requires: gjs >= 1.68.0
+Requires: gjs >= 1.71.1
 Requires: gobject-introspection
 
 %description

--- a/src/consoleReporter.js
+++ b/src/consoleReporter.js
@@ -8,6 +8,11 @@ const GREEN = '\x1b[32m';
 const RED = '\x1b[31m';
 const NORMAL = '\x1b[0m';
 
+let GioUnix = null;
+try {
+    GioUnix = (await import('gi://GioUnix')).default;
+} catch (e) {}
+
 function createNoopTimer() {
     return {
         start() {},
@@ -76,8 +81,11 @@ export const ConsoleReporter = GObject.registerClass({
     // everything)
     static getStdout() {
         if (!this._stdout) {
+            const UnixOutputStream = GioUnix
+                ? GioUnix.OutputStream
+                : Gio.UnixOutputStream;
             const FD_STDOUT = 1;
-            const fdstream = new Gio.UnixOutputStream({
+            const fdstream = new UnixOutputStream({
                 fd: FD_STDOUT,
                 close_fd: false,
             });


### PR DESCRIPTION
Unix-specific API has been split out into a separate GioUnix typelib. While using the symbols from the Gio typelib still works, it now results in a warning.